### PR TITLE
Fix/remove device ready listener

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -317,7 +317,7 @@ $('.passcode-wrapper').each(function(){
         initLockScreen();
         $('.passcode-wrapper').parent().on("fliplet_page_reloaded", initLockScreen);
     } else {
-        Fliplet.then(function() {
+        Fliplet().then(function() {
           initLockScreen();
         });
     }

--- a/js/build.js
+++ b/js/build.js
@@ -314,11 +314,12 @@ $('.passcode-wrapper').each(function(){
     })();
 
     if(Fliplet.Env.get('platform') === 'web') {
-
         initLockScreen();
         $('.passcode-wrapper').parent().on("fliplet_page_reloaded", initLockScreen);
     } else {
-        document.addEventListener("deviceready", initLockScreen);
+        Fliplet.then(function() {
+          initLockScreen();
+        });
     }
 
     function initLockScreen(){


### PR DESCRIPTION
Related to issue https://github.com/Fliplet/fliplet-studio/issues/2005

FIx that will remove the dependency on the deviceReady event for the component to work.