### PR TITLE
Clicking on "Need help" now leads to Fliplet documentation about Lock component

### DIFF
--- a/interface.html
+++ b/interface.html
@@ -2,7 +2,7 @@
   <form class="form-horizontal">
     <header>
       <p>Configure lock component</p>
-      <a id="help_tip" href="#">Need help?</a>
+      <a href="https://help.fliplet.com/article/182-lock-component">Need help?</a>
     </header>
 
     <div class="form-group">

--- a/js/interface.js
+++ b/js/interface.js
@@ -89,10 +89,6 @@ var Lock_screen = (function () {
           _.remove(_this.linkPromises,{id:reset_action_id});
         }
       });
-
-      $('#help_tip').on('click', function() {
-        alert("During beta, please use live chat and let us know what you need help with.");
-      });
     }
   };
 


### PR DESCRIPTION
@tonytlwu @squallstar

Issue
Fliplet/fliplet-studio#4959

Description
Added link on "Need help" button. Removed not needed function.

Backward compatibility
This change is fully backward compatible.