### PR TITLE
OD-789 [Fix] Fixed slide position during animation

### DIFF
--- a/css/build.css
+++ b/css/build.css
@@ -10,8 +10,8 @@
 	right: 0;
 	text-align: center;
 	opacity: 0;
-	-webkit-transition: all 0.5s ease;
-	transition: all 0.5s ease;
+	-webkit-transition: transform 0.5s ease, opacity 0.5s ease;
+	transition: transform 0.5s ease, opacity 0.5s ease;
 	pointer-events: none;
 }
 


### PR DESCRIPTION
@romanyosyfiv

OD-789 https://weboo.atlassian.net/browse/OD-789

## Description
**Problem**: When the sliders switched, the slide position broke. This was because animation was applied to all styles of elements
**Solution**: Animation is used only for slide positioning and opacity

## Screenshots/screencasts
https://user-images.githubusercontent.com/86256215/166649410-b3fbbdbb-3cb5-4400-b9e7-8e59843f8f3f.mp4

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko